### PR TITLE
Caching hull merge costs

### DIFF
--- a/src/test/src/main.cpp
+++ b/src/test/src/main.cpp
@@ -510,8 +510,6 @@ bool LoadOBJ(const string              & fileName,
     {
         char buffer[BufferSize];
         int  ip[3];
-        int  in[3];
-        int  it[3];
         float x[3];
         char * pch;
         char * str;
@@ -567,8 +565,7 @@ bool LoadOBJ(const string              & fileName,
                     if (nt > 0)
                     {
                         pch = strtok(NULL, ObjDelimiters);
-                        if (pch)  it[k] = atoi(pch) - 1;
-                        else
+                        if (!pch)
                         {
                             return false;
                         }
@@ -576,8 +573,7 @@ bool LoadOBJ(const string              & fileName,
                     if (nn > 0)
                     {
                         pch = strtok(NULL, ObjDelimiters);
-                        if (pch)  in[k] = atoi(pch) - 1;
-                        else
+                        if (!pch)
                         {
                             return false;
                         }


### PR DESCRIPTION
This is the code that will cache the cost of merging hulls so we only need to calculate the cost of the new hull versus the other hulls at each merge step. I have tried to follow your coding conventions, but there's a chance you will see bits of my coding style in there.

I think the older version of the code I used when testing the performance may be a little buggy. This newer versions seems to generate fewer hulls for merging so I don't expect the performance improvement to be as good. The test I used for performance testing before was to run all of the data files with the default settings

I have included SSE code to find the minimum element and its index in an array. To compile the SSE code you will need to use the gcc option "-msse4.2" and define USE_SSE. If USE_SSE is not defined the code falls back on scalar search. The SSE codes comes from my implementation of approximate agglomerative clustering, AAC, which performs a lot of these searches. It is therefore very optimised and as a result a little more opaque. A scalar search of the array would simplify the code a bit if this level of optimisation is not required.

I have tested this code on 4-5 objects with the default settings. This isn't an exhaustive test, but things aren't completely broken at least.