### PR TITLE
Added implementation of ComputeClippedVolumes and Intersect for TetrahedronSet

### DIFF
--- a/src/VHACD_Lib/inc/vhacdVolume.h
+++ b/src/VHACD_Lib/inc/vhacdVolume.h
@@ -54,9 +54,6 @@ namespace VHACD
                                                                     SArray< Vec3<double> > * const positivePts,
                                                                     SArray< Vec3<double> > * const negativePts,
                                                               const size_t                         sampling) const = 0;
-        virtual void                                ComputeExteriorPoints(const Plane            &       plane,
-                                                                          const Mesh             &       mesh,
-                                                                          SArray< Vec3<double> > * const exteriorPts) const = 0;
         virtual void                                ComputeClippedVolumes(const Plane  & plane,
                                                                                 double & positiveVolume,
                                                                                 double & negativeVolume) const = 0;
@@ -122,9 +119,6 @@ namespace VHACD
                                                                     SArray< Vec3<double> > * const positivePts,
                                                                     SArray< Vec3<double> > * const negativePts,
                                                               const size_t                         sampling) const;
-        void                                        ComputeExteriorPoints(const Plane            &       plane,
-                                                                          const Mesh             &       mesh,
-                                                                          SArray< Vec3<double> > * const exteriorPts) const;
         void                                        ComputeClippedVolumes(const Plane  & plane,
                                                                           double & positiveVolume,
                                                                           double & negativeVolume) const;
@@ -197,9 +191,6 @@ namespace VHACD
                                                                     SArray< Vec3<double> > * const positivePts,
                                                                     SArray< Vec3<double> > * const negativePts,
                                                               const size_t                         sampling) const;
-        void                                        ComputeExteriorPoints(const Plane            &       plane,
-                                                                          const Mesh             &       mesh,
-                                                                          SArray< Vec3<double> > * const exteriorPts) const;
         void                                        ComputeClippedVolumes(const Plane  & plane,
                                                                                 double & positiveVolume,
                                                                                 double & negativeVolume) const;


### PR DESCRIPTION
This is enough to get the tetrahedron set running. I have tested with a couple of models and everything looks OK.

We could perhaps be more clever with these implementations by splitting tetrahedron that intersect the plane, but I wanted to upload the simpler implementation first. 

We might also be able to split the input mesh straight into tetrahedra instead of first converting to voxels. We would have to be careful on models like bunny that don't form a closed volume