### PR TITLE
Website referenced changed

### DIFF
--- a/src/VHACD_Lib/inc/vhacdICHull.h
+++ b/src/VHACD_Lib/inc/vhacdICHull.h
@@ -19,7 +19,7 @@
 #include "vhacdVector.h"
 
 namespace VHACD {
-//!    Incremental Convex Hull algorithm (cf. http://maven.smith.edu/~orourke/books/ftp.html ).
+//!    Incremental Convex Hull algorithm (cf. http://cs.smith.edu/~orourke/books/ftp.html ).
 enum ICHullError {
     ICHullErrorOK = 0,
     ICHullErrorCoplanarPoints,


### PR DESCRIPTION
Minor fix; the original mavin.smith.edu server/site address can't be reached.  Looks like the URL mentioned in the comment should now be http://cs.smith.edu/~orourke/books/ftp.html