### PR TITLE
Advances cmake_minimum_required

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 project(VHACD)
 option(NO_OPENCL "NO_OPENCL" OFF)
 option(NO_OPENMP "NO_OPENMP" OFF)


### PR DESCRIPTION
CMake 3.0.0 is the bare minimum required, but 3.1.0 is required for OpenCL.

Addresses #31