### PR TITLE
btScalar: Don't use SSE intrinsics on MSVC ARM (UWP)

### DIFF
--- a/src/VHACD_Lib/inc/btScalar.h
+++ b/src/VHACD_Lib/inc/btScalar.h
@@ -64,7 +64,7 @@ inline int32_t btGetVersion()
 #define btFsel(a, b, c) __fsel((a), (b), (c))
 #else
 
-#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
+#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM))
 #define BT_USE_SSE
 #include <emmintrin.h>
 #endif


### PR DESCRIPTION
Without this change build would fail at least for UWP ARM targets with MSVC 2017.