### PR TITLE
Fix scale calculation in Voxel::Voxelize().

### DIFF
--- a/src/VHACD_Lib/inc/vhacdVolume.h
+++ b/src/VHACD_Lib/inc/vhacdVolume.h
@@ -316,13 +316,13 @@ void Volume::Voxelize(const T* const points, const uint32_t stridePoints, const 
 
     double d[3] = { m_maxBB[0] - m_minBB[0], m_maxBB[1] - m_minBB[1], m_maxBB[2] - m_minBB[2] };
     double r;
-    if (d[0] > d[1] && d[0] > d[2]) {
+    if (d[0] >= d[1] && d[0] >= d[2]) {
         r = d[0];
         m_dim[0] = dim;
         m_dim[1] = 2 + static_cast<size_t>(dim * d[1] / d[0]);
         m_dim[2] = 2 + static_cast<size_t>(dim * d[2] / d[0]);
     }
-    else if (d[1] > d[0] && d[1] > d[2]) {
+    else if (d[1] >= d[0] && d[1] >= d[2]) {
         r = d[1];
         m_dim[1] = dim;
         m_dim[0] = 2 + static_cast<size_t>(dim * d[0] / d[1]);


### PR DESCRIPTION
Scale should use the maximum bounding box dimension. However, if the first two bounding box dimensions are equal, but greater than the third, scale is currently incorrectly calculated using the third.

This patch ensures that if the first two bounding box dimensions are equal, and greater than or equal to the third, the first bounding box dimension is used.

