### PR TITLE
Fix order of Simplify and Merge convex hulls

### DIFF
--- a/src/VHACD_Lib/inc/vhacdVHACD.h
+++ b/src/VHACD_Lib/inc/vhacdVHACD.h
@@ -259,8 +259,8 @@ private:
         VoxelizeMesh(points, nPoints, (int32_t*)triangles, nTriangles, params);
         ComputePrimitiveSet(params);
         ComputeACD(params);
-        SimplifyConvexHulls(params);
         MergeConvexHulls(params);
+        SimplifyConvexHulls(params);
         if (GetCancel())
         {
             //printf("EarlyOut:ComputeACD::Clean\n");


### PR DESCRIPTION
Fixed the order of SimplifyConvexHulls and MergeConvexHulls calls introduced in https://github.com/kmammou/v-hacd/commit/cb63b79a666b81ceff691eb685b79bb3c449fdd4

Now correctly merges before simplifying. Fixes issue causing resulting convex hull(s) to have vertices greater than specified m_maxNumVerticesPerCH