### PR TITLE
Remove useless const modifiers on return types

### DIFF
--- a/src/VHACD_Lib/inc/vhacdMesh.h
+++ b/src/VHACD_Lib/inc/vhacdMesh.h
@@ -70,18 +70,18 @@ public:
     Vec3<double>& GetPoint(size_t index) { return m_points[index]; };
     size_t GetNPoints() const { return m_points.Size(); };
     double* GetPoints() { return (double*)m_points.Data(); } // ugly
-    const double* const GetPoints() const { return (double*)m_points.Data(); } // ugly
-    const Vec3<double>* const GetPointsBuffer() const { return m_points.Data(); } //
-    Vec3<double>* const GetPointsBuffer() { return m_points.Data(); } //
+    const double* GetPoints() const { return (double*)m_points.Data(); } // ugly
+    const Vec3<double>* GetPointsBuffer() const { return m_points.Data(); } //
+    Vec3<double>* GetPointsBuffer() { return m_points.Data(); } //
     void AddTriangle(const Vec3<int32_t>& tri) { m_triangles.PushBack(tri); };
     void SetTriangle(size_t index, const Vec3<int32_t>& tri) { m_triangles[index] = tri; };
     const Vec3<int32_t>& GetTriangle(size_t index) const { return m_triangles[index]; };
     Vec3<int32_t>& GetTriangle(size_t index) { return m_triangles[index]; };
     size_t GetNTriangles() const { return m_triangles.Size(); };
     int32_t* GetTriangles() { return (int32_t*)m_triangles.Data(); } // ugly
-    const int32_t* const GetTriangles() const { return (int32_t*)m_triangles.Data(); } // ugly
-    const Vec3<int32_t>* const GetTrianglesBuffer() const { return m_triangles.Data(); }
-    Vec3<int32_t>* const GetTrianglesBuffer() { return m_triangles.Data(); }
+    const int32_t* GetTriangles() const { return (int32_t*)m_triangles.Data(); } // ugly
+    const Vec3<int32_t>* GetTrianglesBuffer() const { return m_triangles.Data(); }
+    Vec3<int32_t>* GetTrianglesBuffer() { return m_triangles.Data(); }
     const Vec3<double>& GetCenter() const { return m_center; }
     const Vec3<double>& GetMinBB() const { return m_minBB; }
     const Vec3<double>& GetMaxBB() const { return m_maxBB; }

--- a/src/VHACD_Lib/inc/vhacdSArray.h
+++ b/src/VHACD_Lib/inc/vhacdSArray.h
@@ -40,11 +40,11 @@ public:
     {
         return m_size;
     }
-    T* const Data()
+    T* Data()
     {
         return (m_maxSize == N) ? m_data0 : m_data;
     }
-    const T* const Data() const
+    const T* Data() const
     {
         return (m_maxSize == N) ? m_data0 : m_data;
     }

--- a/src/VHACD_Lib/inc/vhacdVector.h
+++ b/src/VHACD_Lib/inc/vhacdVector.h
@@ -160,7 +160,7 @@ private:
 };
 
 template <typename T>
-const bool Colinear(const Vec3<T>& a, const Vec3<T>& b, const Vec3<T>& c);
+bool Colinear(const Vec3<T>& a, const Vec3<T>& b, const Vec3<T>& c);
 template <typename T>
 const T ComputeVolume4(const Vec3<T>& a, const Vec3<T>& b, const Vec3<T>& c, const Vec3<T>& d);
 }

--- a/src/VHACD_Lib/inc/vhacdVector.inl
+++ b/src/VHACD_Lib/inc/vhacdVector.inl
@@ -162,7 +162,7 @@ namespace VHACD
     inline Vec3<T>::Vec3() {}
     
     template<typename T>
-    inline const bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c)
+    inline bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c)
     {
         return  ((c.Z() - a.Z()) * (b.Y() - a.Y()) - (b.Z() - a.Z()) * (c.Y() - a.Y()) == 0.0 /*EPS*/) &&
                 ((b.Z() - a.Z()) * (c.X() - a.X()) - (b.X() - a.X()) * (c.Z() - a.Z()) == 0.0 /*EPS*/) &&
@@ -343,7 +343,7 @@ namespace VHACD
      defined by A, B, C.
    */
     template<typename T>
-    inline const bool InsideTriangle(const Vec2<T> & a, const Vec2<T> & b, const Vec2<T> & c, const Vec2<T> & p)
+    inline bool InsideTriangle(const Vec2<T> & a, const Vec2<T> & b, const Vec2<T> & c, const Vec2<T> & p)
     {
         T ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
         T cCROSSap, bCROSScp, aCROSSbp;

--- a/src/VHACD_Lib/inc/vhacdVolume.h
+++ b/src/VHACD_Lib/inc/vhacdVolume.h
@@ -43,12 +43,12 @@ class PrimitiveSet {
 public:
     virtual ~PrimitiveSet(){};
     virtual PrimitiveSet* Create() const = 0;
-    virtual const size_t GetNPrimitives() const = 0;
-    virtual const size_t GetNPrimitivesOnSurf() const = 0;
-    virtual const size_t GetNPrimitivesInsideSurf() const = 0;
-    virtual const double GetEigenValue(AXIS axis) const = 0;
-    virtual const double ComputeMaxVolumeError() const = 0;
-    virtual const double ComputeVolume() const = 0;
+    virtual size_t GetNPrimitives() const = 0;
+    virtual size_t GetNPrimitivesOnSurf() const = 0;
+    virtual size_t GetNPrimitivesInsideSurf() const = 0;
+    virtual double GetEigenValue(AXIS axis) const = 0;
+    virtual double ComputeMaxVolumeError() const = 0;
+    virtual double ComputeVolume() const = 0;
     virtual void Clip(const Plane& plane, PrimitiveSet* const positivePart,
         PrimitiveSet* const negativePart) const = 0;
     virtual void Intersect(const Plane& plane, SArray<Vec3<double> >* const positivePts,
@@ -80,12 +80,12 @@ public:
     //! Constructor.
     VoxelSet();
 
-    const size_t GetNPrimitives() const { return m_voxels.Size(); }
-    const size_t GetNPrimitivesOnSurf() const { return m_numVoxelsOnSurface; }
-    const size_t GetNPrimitivesInsideSurf() const { return m_numVoxelsInsideSurface; }
-    const double GetEigenValue(AXIS axis) const { return m_D[axis][axis]; }
-    const double ComputeVolume() const { return m_unitVolume * m_voxels.Size(); }
-    const double ComputeMaxVolumeError() const { return m_unitVolume * m_numVoxelsOnSurface; }
+    size_t GetNPrimitives() const { return m_voxels.Size(); }
+    size_t GetNPrimitivesOnSurf() const { return m_numVoxelsOnSurface; }
+    size_t GetNPrimitivesInsideSurf() const { return m_numVoxelsInsideSurface; }
+    double GetEigenValue(AXIS axis) const { return m_D[axis][axis]; }
+    double ComputeVolume() const { return m_unitVolume * m_voxels.Size(); }
+    double ComputeMaxVolumeError() const { return m_unitVolume * m_numVoxelsOnSurface; }
     const Vec3<short>& GetMinBBVoxels() const { return m_minBBVoxels; }
     const Vec3<short>& GetMaxBBVoxels() const { return m_maxBBVoxels; }
     const Vec3<double>& GetMinBB() const { return m_minBB; }
@@ -127,8 +127,8 @@ public:
     }
     void AlignToPrincipalAxes(){};
     void RevertAlignToPrincipalAxes(){};
-    Voxel* const GetVoxels() { return m_voxels.Data(); }
-    const Voxel* const GetVoxels() const { return m_voxels.Data(); }
+    Voxel* GetVoxels() { return m_voxels.Data(); }
+    const Voxel* GetVoxels() const { return m_voxels.Data(); }
 
 private:
     size_t m_numVoxelsOnSurface;
@@ -163,16 +163,16 @@ public:
     //! Constructor.
     TetrahedronSet();
 
-    const size_t GetNPrimitives() const { return m_tetrahedra.Size(); }
-    const size_t GetNPrimitivesOnSurf() const { return m_numTetrahedraOnSurface; }
-    const size_t GetNPrimitivesInsideSurf() const { return m_numTetrahedraInsideSurface; }
+    size_t GetNPrimitives() const { return m_tetrahedra.Size(); }
+    size_t GetNPrimitivesOnSurf() const { return m_numTetrahedraOnSurface; }
+    size_t GetNPrimitivesInsideSurf() const { return m_numTetrahedraInsideSurface; }
     const Vec3<double>& GetMinBB() const { return m_minBB; }
     const Vec3<double>& GetMaxBB() const { return m_maxBB; }
     const Vec3<double>& GetBarycenter() const { return m_barycenter; }
-    const double GetEigenValue(AXIS axis) const { return m_D[axis][axis]; }
-    const double GetSacle() const { return m_scale; }
-    const double ComputeVolume() const;
-    const double ComputeMaxVolumeError() const;
+    double GetEigenValue(AXIS axis) const { return m_D[axis][axis]; }
+    double GetSacle() const { return m_scale; }
+    double ComputeVolume() const;
+    double ComputeMaxVolumeError() const;
     void ComputeConvexHull(Mesh& meshCH, const size_t sampling = 1) const;
     void ComputePrincipalAxes();
     void AlignToPrincipalAxes();
@@ -235,8 +235,8 @@ public:
         assert(k < m_dim[0] || k >= 0);
         return m_data[i + j * m_dim[0] + k * m_dim[0] * m_dim[1]];
     }
-    const size_t GetNPrimitivesOnSurf() const { return m_numVoxelsOnSurface; }
-    const size_t GetNPrimitivesInsideSurf() const { return m_numVoxelsInsideSurface; }
+    size_t GetNPrimitivesOnSurf() const { return m_numVoxelsOnSurface; }
+    size_t GetNPrimitivesInsideSurf() const { return m_numVoxelsInsideSurface; }
     void Convert(Mesh& mesh, const VOXEL_VALUE value) const;
     void Convert(VoxelSet& vset) const;
     void Convert(TetrahedronSet& tset) const;

--- a/src/VHACD_Lib/src/vhacdVolume.cpp
+++ b/src/VHACD_Lib/src/vhacdVolume.cpp
@@ -1524,7 +1524,7 @@ void TetrahedronSet::Convert(Mesh& mesh, const VOXEL_VALUE value) const
         }
     }
 }
-const double TetrahedronSet::ComputeVolume() const
+double TetrahedronSet::ComputeVolume() const
 {
     const size_t nTetrahedra = m_tetrahedra.Size();
     if (nTetrahedra == 0)
@@ -1536,7 +1536,7 @@ const double TetrahedronSet::ComputeVolume() const
     }
     return volume / 6.0;
 }
-const double TetrahedronSet::ComputeMaxVolumeError() const
+double TetrahedronSet::ComputeMaxVolumeError() const
 {
     const size_t nTetrahedra = m_tetrahedra.Size();
     if (nTetrahedra == 0)


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/kmammou/v-hacd/?mode=tree), `const` modifiers on return types have no effect and should be removed, because they may suggest a method or the pointer returned by the method is `const` when it isn't, This PR removes the useless `const`s.