### PR TITLE
fixed memory leaking

### DIFF
--- a/include/VHACD.h
+++ b/include/VHACD.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2011 Khaled Mamou (kmamou at gmail dot com)
+/* Copyright (c) 2011 Khaled Mamou (kmamou at gmail dot com)
  All rights reserved.
  
  
@@ -4002,7 +4002,7 @@ public:
         mRoot = 0;
         mVerticesDouble.clear();
         mVerticesFloat.clear();
-        KdTreeNodeBundle* bundle = mBundle;
+        KdTreeNodeBundle* bundle = mBundleHead;
         while (bundle)
         {
             KdTreeNodeBundle* next = bundle->mNext;
@@ -4010,6 +4010,7 @@ public:
             bundle = next;
         }
         mBundle = 0;
+        mBundleHead = 0;
         mVcount = 0;
     }
 
@@ -4058,6 +4059,7 @@ public:
         if (mBundle == 0)
         {
             mBundle = new KdTreeNodeBundle;
+            mBundleHead = mBundle;
         }
         if (mBundle->isFull())
         {
@@ -4142,6 +4144,8 @@ private:
     bool mUseDouble;
     KdTreeNode* mRoot;
     KdTreeNodeBundle* mBundle;
+    KdTreeNodeBundle* mBundleHead = NULL;
+
     uint32_t mVcount;
     DoubleVector mVerticesDouble;
     FloatVector mVerticesFloat;


### PR DESCRIPTION
There is a memory leaking problem in the KdTree class. When a new KdTreeNodeBundle is allocated in the getNewNode function, the pointer mBundle will move to the next pointer in the linked list. Therefore, the reset function is not able to release all allocated bundles, because the pointer (bundle) will point to mBundle, which is at the end of the linked list. The solution is to save the head of the KdTreeNodeBundle linked list, and point (bundle) to the head of linked list.