### PR TITLE
feat(TestVHACD): add single objects to full decomp.obj file.

### DIFF
--- a/app/TestVHACD.cpp
+++ b/app/TestVHACD.cpp
@@ -487,7 +487,9 @@ int main(int argc,const char **argv)
 						printf("Saving Convex Decomposition results of %d convex hulls to 'decomp.obj'\n", iface->GetNConvexHulls());
 						uint32_t baseIndex = 1;
 						for (uint32_t i=0; i<iface->GetNConvexHulls(); i++)
-						{
+						{	
+							// add an object name for each single convex hull
+							fprintf(fph,"o %s%03d\n", baseName.c_str(), i);
 							VHACD::IVHACD::ConvexHull ch;
 							iface->GetConvexHull(i,ch);
 							for (uint32_t j=0; j<ch.m_nPoints; j++)


### PR DESCRIPTION
This makes the loading of the full file easier as all different single objects are visualized and useable in different tools for example blender.

From [Wikipedia](https://en.wikipedia.org/wiki/Wavefront_.obj_file):

Named objects and polygon groups are specified via the following tags.
```
o [object name]
```

This is needed for [BlenderProc](https://github.com/DLR-RM/BlenderProc), which uses V-HACD :) 