### PR TITLE
Move include of <algorithm> up, for std::min/max_element.

### DIFF
--- a/include/VHACD.h
+++ b/include/VHACD.h
@@ -113,6 +113,7 @@
 #include <vector>
 #include <array>
 #include <cmath>
+#include <algorithm>
 
 namespace VHACD {
 
@@ -891,7 +892,6 @@ IVHACD* CreateVHACD_ASYNC();    // Create an asynchronous (non-blocking) impleme
 #include <float.h>
 #include <limits.h>
 
-#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
Due to moving the vector3 implementation out of ENABLE_VHACD_IMPLEMENTATION we now also need <algorithm> outside of this, or in some compile cases std::min/max_element would be unknown.