### PR TITLE
Remove the upscaling of the voxel size in shrink-wrap

### DIFF
--- a/include/VHACD.h
+++ b/include/VHACD.h
@@ -7823,7 +7823,7 @@ IVHACD::ConvexHull* VHACDImpl::ComputeReducedConvexHull(const ConvexHull& ch,
     ShrinkWrap(sourceConvexHull,
                m_AABBTree,
                maxVerts,
-               m_voxelScale * 4,
+               m_voxelScale,
                projectHullVertices);
 
     ConvexHull *ret = new ConvexHull;


### PR DESCRIPTION
**Issue:**
The ShrinkWrap tightens the convex hulls to reduce the conservativeness of the convex hulls compared to the original geometry. But it also results in "leakage" of the original geometry, that is in some areas the convex hull shrinks too much and becomes less conservative than the original geometry as shown in the left image below.

**Solution:**
As the distance threshold parameter of the shrinkwrap, the voxel size scaled by factor of 4 is passed. It is not clear to me why that is. But removing that factor, and therefore using a smaller distance threshold seems to reduce the leakage as shown in the right image below.

![image](https://github.com/kmammou/v-hacd/assets/16369053/874a6ca9-2d0f-44ea-94f6-811b0a1e4bae)
